### PR TITLE
Fixes issue #3 list items are not refreshed when the items’ source e.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Next]
+* Fixes issue #3 list items are not refreshed when the items’ source e.g. a change notifier Provider sends an updated list.
+* Corrects spelling mistakes in documentation.
+
 ## [6.5.0-beta]
 * type fixes
 

--- a/lib/src/widget/s2_state.dart
+++ b/lib/src/widget/s2_state.dart
@@ -3,8 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_awesome_select/flutter_awesome_select.dart';
 import '../state/choices.dart';
 import '../state/filter.dart';
-// import 'state/selected.dart';
-// import 'state/selection.dart';
 import '../choices_resolver.dart';
 import '../utils/debouncer.dart';
 import '../choices_list.dart';
@@ -855,6 +853,10 @@ abstract class S2State<T> extends State<SmartSelect<T>> {
     if (!const ListEquality()
         .equals(oldWidget.choiceItems, widget.choiceItems)) {
       resolveChoices();
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        choices?.reload();
+        modalSetState?.call(() {});
+      });
     }
   }
 

--- a/lib/src/widget/smart_select.dart
+++ b/lib/src/widget/smart_select.dart
@@ -283,7 +283,7 @@ class SmartSelect<T> extends StatefulWidget {
   ///
   /// The [groupConfig] is a configuration to customize grouped widget.
   ///
-  /// The [groupEnabled] is shortcut to [groupConfig.enabled], alterative to [choiceGrouped],
+  /// The [groupEnabled] is shortcut to [groupConfig.enabled], alternative to [choiceGrouped],
   /// whether the choices list is grouped or not, based on [S2Choice.group].
   ///
   /// The [groupSelector] is shortcut to [groupConfig.useSelector],
@@ -607,7 +607,7 @@ class SmartSelect<T> extends StatefulWidget {
   ///
   /// The [groupConfig] is a configuration to customize grouped widget.
   ///
-  /// The [groupEnabled] is shortcut to [groupConfig.enabled], alterative to [choiceGrouped],
+  /// The [groupEnabled] is shortcut to [groupConfig.enabled], alternative to [choiceGrouped],
   /// whether the choices list is grouped or not, based on [S2Choice.group].
   ///
   /// The [groupSelector] is shortcut to [groupConfig.useSelector],


### PR DESCRIPTION
Fixes issue #3 list items are not refreshed when the items’ source e.g. a change notifier Provider sends an updated list.
Corrects spelling mistakes in documentation.