### PR TITLE
Fixes #24. Adds new configurable option to not shrink wrap list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Next]
+* Adds new configurable option to not shrink wrap list items using `S2ChoiceConfig.shrinkWrap` or `SmartSelect.single.choiceShrinkWrap`/`SmartSelect.multiple.choiceShrinkWrap`.
+  If `choiceShrinkWrap` is true choices list will shrink wrap the choices, causing the list to resize based on the number of available choices, by default it will shrink wrap which was the default behaviour before this change.
+
 ## [6.5.0-beta]
 * type fixes
 

--- a/lib/src/choices_list.dart
+++ b/lib/src/choices_list.dart
@@ -71,7 +71,7 @@ class S2ChoicesList<T> extends StatelessWidget {
 
   Widget _listDefault() {
     return ListView.builder(
-      shrinkWrap: true,
+      shrinkWrap: config.shrinkWrap,
       physics: config.physics,
       scrollDirection: config.direction,
       padding: config.padding ?? const EdgeInsets.symmetric(vertical: 10.0),
@@ -82,7 +82,7 @@ class S2ChoicesList<T> extends StatelessWidget {
 
   Widget _listSeparated() {
     return ListView.separated(
-      shrinkWrap: true,
+      shrinkWrap: config.shrinkWrap,
       physics: config.physics,
       scrollDirection: config.direction,
       padding: config.padding ?? const EdgeInsets.symmetric(vertical: 10.0),
@@ -94,7 +94,7 @@ class S2ChoicesList<T> extends StatelessWidget {
 
   Widget _listGrid() {
     return GridView.builder(
-      shrinkWrap: true,
+      shrinkWrap: config.shrinkWrap,
       physics: config.physics,
       scrollDirection: config.direction,
       padding: config.padding ?? const EdgeInsets.all(10.0),

--- a/lib/src/model/choice_config.dart
+++ b/lib/src/model/choice_config.dart
@@ -110,6 +110,10 @@ class S2ChoiceConfig with Diagnosticable {
   /// Time delay before display the choices
   final Duration? delay;
 
+  /// If true choices list will shrink wrap the choices, causing the list to
+  /// resize based on the number of available choices.
+  final bool shrinkWrap;
+
   /// Create choices configuration
   const S2ChoiceConfig({
     this.type,
@@ -131,6 +135,7 @@ class S2ChoiceConfig with Diagnosticable {
     this.physics = const ScrollPhysics(),
     this.pageLimit,
     this.delay,
+    this.shrinkWrap = true,
   });
 
   /// Whether the [layout] is [S2ChoiceLayout.wrap] or [type] is [S2ChoiceType.chips]
@@ -166,6 +171,7 @@ class S2ChoiceConfig with Diagnosticable {
     ScrollPhysics? physics,
     int? pageLimit,
     Duration? delay,
+    bool? shrinkWrap,
   }) {
     return S2ChoiceConfig(
       type: type ?? this.type,
@@ -187,6 +193,7 @@ class S2ChoiceConfig with Diagnosticable {
       physics: physics ?? this.physics,
       pageLimit: pageLimit ?? this.pageLimit,
       delay: delay ?? this.delay,
+      shrinkWrap: shrinkWrap ?? this.shrinkWrap,
     );
   }
 
@@ -216,6 +223,7 @@ class S2ChoiceConfig with Diagnosticable {
       physics: other.physics,
       pageLimit: other.pageLimit,
       delay: other.delay,
+      shrinkWrap: other.shrinkWrap,
     );
   }
 }

--- a/lib/src/widget/smart_select.dart
+++ b/lib/src/widget/smart_select.dart
@@ -281,6 +281,9 @@ class SmartSelect<T> extends StatefulWidget {
   /// The [choiceDelay] is shortcut to [choiceConfig.delay],
   /// time delay before display the choices.
   ///
+  /// If [choiceShrinkWrap] is true choices list will shrink wrap the choices,
+  /// causing the list to resize based on the number of available choices.
+  ///
   /// The [groupConfig] is a configuration to customize grouped widget.
   ///
   /// The [groupEnabled] is shortcut to [groupConfig.enabled], alterative to [choiceGrouped],
@@ -377,6 +380,7 @@ class SmartSelect<T> extends StatefulWidget {
     double? choiceGridSpacing,
     int? choicePageLimit,
     Duration? choiceDelay,
+    bool? choiceShrinkWrap,
     S2GroupConfig? groupConfig,
     bool? groupEnabled,
     bool? groupSelector,
@@ -452,6 +456,7 @@ class SmartSelect<T> extends StatefulWidget {
             activeStyle: choiceActiveStyle,
             pageLimit: choicePageLimit,
             delay: choiceDelay,
+            shrinkWrap: choiceShrinkWrap,
           ),
       groupConfig: defaultGroupConfig.merge(groupConfig).copyWith(
             enabled: groupEnabled ?? choiceGrouped,
@@ -605,6 +610,9 @@ class SmartSelect<T> extends StatefulWidget {
   /// The [choiceDelay] is shortcut to [choiceConfig.delay],
   /// time delay before display the choices.
   ///
+  /// If [choiceShrinkWrap] is true choices list will shrink wrap the choices,
+  /// causing the list to resize based on the number of available choices.
+  ///
   /// The [groupConfig] is a configuration to customize grouped widget.
   ///
   /// The [groupEnabled] is shortcut to [groupConfig.enabled], alterative to [choiceGrouped],
@@ -700,6 +708,7 @@ class SmartSelect<T> extends StatefulWidget {
     double? choiceGridSpacing,
     int? choicePageLimit,
     Duration? choiceDelay,
+    bool? choiceShrinkWrap,
     S2GroupConfig? groupConfig,
     bool? groupEnabled,
     bool? groupSelector,
@@ -775,6 +784,7 @@ class SmartSelect<T> extends StatefulWidget {
             activeStyle: choiceActiveStyle,
             pageLimit: choicePageLimit,
             delay: choiceDelay,
+            shrinkWrap: choiceShrinkWrap,
           ),
       groupConfig: defaultGroupConfig.merge(groupConfig).copyWith(
             enabled: groupEnabled ?? choiceGrouped,


### PR DESCRIPTION
Fixes #24. Adds new configurable option to not shrink wrap list items using `S2ChoiceConfig.shrinkWrap` or `SmartSelect.single.choiceShrinkWrap`/`SmartSelect.multiple.choiceShrinkWrap`.
If `choiceShrinkWrap` is true choices list will shrink wrap the choices, causing the list to resize based on the number of available choices, by default it will shrink wrap which was the default behaviour before this change.

**Usage:**
```dart
SmartSelect<T?>.single(
  choiceShrinkWrap: false
);
```

```dart
SmartSelect<T?>.multiple(
  choiceShrinkWrap: false
);
```

After fix if you pass `SmartSelect.single.choiceShrinkWrap`=`false`

https://user-images.githubusercontent.com/1186833/193662296-8283955b-db87-44f4-b5a7-8d0fa7359912.mp4